### PR TITLE
Fix GitLab Runner rootless builds

### DIFF
--- a/apps/gitlab/gitlab-runner/secret.template
+++ b/apps/gitlab/gitlab-runner/secret.template
@@ -12,6 +12,11 @@ stringData:
             [[runners]]
               [runners.kubernetes]
                 image = "alpine:latest"
+                [runners.kubernetes.build_container_security_context]
+                  [runners.kubernetes.build_container_security_context.seccomp_profile]
+                    type = "Unconfined"
+                  [runners.kubernetes.build_container_security_context.app_armor_profile]
+                    type = "Unconfined"
               [runners.cache]
                 Type = "s3"
                 Path = "cache"

--- a/apps/gitlab/gitlab-runner/secret.yaml
+++ b/apps/gitlab/gitlab-runner/secret.yaml
@@ -5,10 +5,11 @@ metadata:
     namespace: gitlab
 type: Opaque
 stringData:
-    values.yaml: ENC[AES256_GCM,data:sU1bLJNtT6YNo1mpw5iAh/XSS0yu+s5N7frRiXI+Dp6LvW0RQCn9b5tWL32CvDguThTfl4a+CbOSIFezu96nXy1WX+YCiOeP5JrF5XItoOeBTka1WLiP8t+hOS2yjaP3JuU9DGBNwGBP9kU6UcXW3N7yy5rz5cg8LGM4VeKpBwJEXsnioqyflzCOuXx07KPH43KwTFew38+NnOttShSY694vpWFJx5Yj8xQt/NkJ7g13Aw57a3iYfb/3sUV+O+Czj7CrEcqMDp5kQJHZ/ijYhYDoy7vypAqKdbwOdozkKGFvyUHP+v3U2srB1axA3yYYNoTFRqIySHX5I6Zuk4NPETxBAPMqJwghUuBlnQ/crsY1YoqwHtkPjNsdF9Aj6JrZ3IozQsLgejtTiUjIBKQuyrLJn38NaeodCXopRtDC//io0QMOV1UWVLQr8IQsohkFKI4s6LIvlR4HqRinLsWJ5jsrUhNKtWJq+bIECpzKlWeXx40iddFE/cpbGwnKCWqRKkkwLkIorlT/1EHP94J76enpUkXTDczucZ2kkcz+L09DREJ3U1ZpkMiDYrsaJojIEwsG7ynimgJASM2MM9Ta/5oKIBcroTxvrDbkuJAkYVn6kVQ5lHapXRuYE/j4lHq/LTB4WKiaqD8uBkJhmDKE3YPV6fUUBsUKTD/bIdnHfpshshviDvOpPNx+8eFQwKhMHpBmb3C5/urf9y5BV5J92NMYld7FV++Dx8SSrHPyPmhv,iv:wntld+/ox+LdMzK9FsI9CEu2fxKdOUM005K7rU+c5ng=,tag:sofAUBNyBlqvZJ+fn460sQ==,type:str]
+    values.yaml: ENC[AES256_GCM,data:Mfr8u2SSm8VSoVdU9Gyw+0HFHDDTBSyR3zPSnQ1uoZlY1RUcu25KF2Z0fXdhmfnGw9+C733i8GQYuFhT7qif65dH76vE/mGLHZQoXFJBC3pS39Xqqpixp69WqgK+2s6ZG9eqnUa6c/QWrg9s9mYO7NPMDzW8FbAHjJHGToUuLd401Kra7mgmt3nj89rpikXOTnBAdPRSBok8lbW9ZV7X2T5GuFzDObFBC3+NpyUIDutykq5Z4s1Ahvvs8nkmSto8PYKM+NjorHT54AH36KuthUL0RNJBEd90ICAiAFEQTvPZclpqwTCSQrLmIqGzzx7XssnqP8KO9RDU8xtTfN+AFBo78/kEqkgnAkoormne0l6qZCZYYeG8WPEYZrWNbkWaBZwuwsTj6V4tovIhiGLp7jGGePrDD6skiXEeBRs2zc+sLJ+mriRXONzh9lXtC0LoPUFKiS5byMBrpImtZHSLNqhh+2jY13XVB6Bzv05YN8qrvvSzFeLYbVnLW9BAyQrDmX1jjAINfFpLqHp99KxjuOV5bLTkoPJF+cdLafkpMBWeiXI4NETdoy6DdSRVuYxIlRHyZdv6ShXgYs4TG5eJd5Nv/zxYLJdpCK+XsVwaXQsA6l8NZEyvC32/ZvSxrKTRJ+Jav5ZFa3bGRT6po18aT4A/N/aozBj3Fo1WcCrdtTo9OQJo2lqQHPApfMxCAcHeN82woomyB9RxWGE9okcQC0rKbwq4o9SUYyVKtZTkuSGQMvxG8LS1fvS0tm9CEkD5ospNaJroYkjliRcp1LGUDydvEtxML1iihhlDJOMr1h5RqOsHAq7fhR40P7fXmdIhpYG4OYiH1tomU+aY+sclxporDQg1YKpAHv6tRV8f+5eYiqm4/aX1gex+NkrOqbUfJ0XAUIvMH4LlaihTZ0ZfMzy35GWi7f7V6BcLZ1RQLII2nByZzmRMBdorvOIC0F3S8LSJZ08+etY10FyXMGTCzXrkCjfpqZCCkLnVusv2SC/p0vkjSB8zsp/mrDsjTHJjS5Kyh+Frr4w9/Pu6zQCj8dYNNLN8V2eDSDAxP9k5+gLqn31MDVcsUcnLGen25QQ6D/j2eeiMbrDssNZAgeVzdr+/UNunqSM+lkkVGELoYvfG,iv:VjVWytP+Wh6yZIazoIB2vpqk8vv8BgcKjHwp00nEDC8=,tag:9O4rTJDX23+0CcXdrXzEaA==,type:str]
 sops:
-    lastmodified: "2026-02-24T21:09:53Z"
-    mac: ENC[AES256_GCM,data:VKoVGDa1LsmhlwcgxbnFOIrA/ykn4JvVJDa028qK0kjqu+TMeu4I3QJRGEUWRHGciL+Dzc8CCBK+NNLdQHSkMb1ctQsfGY5eNa62NEsT56v0YksT7vgnCrrc2tRN1mD6vMW7jWPhU31OS0+pBme6coxCYFU1PiQm0ted1zdygyQ=,iv:VlzH5V6JBRCpkM2gQ4tn2T7a2cPIKi7gjRwHWJzDyS0=,tag:Bfg8FzoFPh/dbLxAQuS96g==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-10T17:08:19Z"
+    mac: ENC[AES256_GCM,data:3oTZEzcmZHhuYeb87qSxt7aNumzm5ij8sId/XN/x6X9FXMdpQl0sNB9gowDZLFXD/ffSx8I5vtp9twHVnhKKzrOCCVBlEW41kt3hLg6OrKe0Jwt1KA+dKv44zwsQ3ypFSM2EAgd/MypvoEF0KVLADL3kkxHAvywxK2QqLeCnCgU=,iv:LHqz1xSNBwfXvPQtCsZWCtiBi0Bgdw2XpbqJ9oooBBg=,tag:kfftD9HxWb75zR7IooK2sA==,type:str]
     pgp:
         - created_at: "2026-02-24T21:09:53Z"
           enc: |-
@@ -31,5 +32,4 @@ sops:
             =+a3K
             -----END PGP MESSAGE-----
           fp: 4988A3C9ED6515B2E192F0ABE42278AB326CB047
-    encrypted_regex: ^(data|stringData)$
     version: 3.12.1


### PR DESCRIPTION
## What changed

Configure the GitLab Runner Kubernetes build container with unconfined seccomp and AppArmor profiles. The encrypted live Helm values and the generated secret template are kept in sync.

## Why

GitLab job 53603 fails before BuildKit starts with:

```
[rootlesskit:child ] error: failed to share mount point: /: permission denied
```

AppArmor blocks the mount operation rootlesskit needs. Rootless BuildKit's Kubernetes configuration also requires an unconfined seccomp profile.

## Impact

Rootless image-build jobs can start BuildKit successfully. The relaxed profiles apply only to the GitLab Runner build container, not helper or service containers.

## Validation

- Decrypted runner config parses as TOML and contains both expected profiles
- GitLab Runner Helm chart `0.91.0` renders successfully with the encrypted values
- `git diff --check` passes

After merge and Flux reconciliation, retry GitLab job 53603.